### PR TITLE
Style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,22 @@ Dangerous `any` types can come from surprising places in TypeScript. This VS Cod
 
 ## Extension Settings
 
-No settings for now.
+`anyXray.anyStyle`
+
+Change the way that symbols with `any` types are rendered. You can pass in anything assignable to [`DecorationRenderOptions`][style]. The default is:
+
+```json
+{
+  "backgroundColor": "rgba(255,0,0,0.1)",
+  "borderRadius": "3px",
+  "border": "solid 1px rgba(255,0,0)",
+  "color": "red"
+}
+```
+
+`anyXray.renderErrorAnys`
+
+When there are errors, the TypeScript language service reports special "error" `any` types. By default, any-xray doesn't render these. But error `any`s can lead to non-error `any`s, so they can be helpful for tracking down why this extension is reporting spurious `any` types. Flip this on to help debug.
 
 ## Related work
 
@@ -20,3 +35,4 @@ No settings for now.
 [type-coverage]: https://github.com/plantain-00/type-coverage
 [no-unsafe-assignment]: https://typescript-eslint.io/rules/no-unsafe-assignment/
 [recommended-type-checked]: https://typescript-eslint.io/users/configs/#recommended-type-checked
+[style]: https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "displayName": "any-xray",
   "description": "Make all the any types visible",
   "version": "0.1.0",
+  "publisher": "danvk",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -32,7 +33,28 @@
     ],
     "grammars": [],
     "commands": [],
-    "keybindings": []
+    "keybindings": [],
+    "configuration": {
+      "title": "Any X-Ray Glasses",
+      "properties": {
+        "anyXray.anyStyle": {
+          "type": "object",
+          "default": {
+            "backgroundColor": "rgba(255,0,0,0.1)",
+            "borderRadius": "3px",
+            "border": "solid 1px rgba(255,0,0)",
+            "color": "red"
+          },
+          "description": "camelCased CSS styles to apply to 'any' types",
+          "editPresentation": "multilineText"
+        },
+        "anyXray.renderErrorAnys": {
+          "type": "boolean",
+          "default": false,
+          "description": "Render 'any' types coming from errors; this is mostly useful for debugging."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,8 @@
       "title": "Any X-Ray Glasses",
       "properties": {
         "anyXray.anyStyle": {
-          "type": "object",
-          "default": {
-            "backgroundColor": "rgba(255,0,0,0.1)",
-            "borderRadius": "3px",
-            "border": "solid 1px rgba(255,0,0)",
-            "color": "red"
-          },
+          "type": ["object", "null"],
+          "default": null,
           "description": "camelCased CSS styles to apply to 'any' types",
           "editPresentation": "multilineText"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,9 @@ import * as path from 'path';
 import * as fs from 'fs';
 import debounce from 'lodash.debounce';
 
-const decorationType = vscode.window.createTextEditorDecorationType({
-  backgroundColor: 'rgba(255,0,0,0.1)', // Red translucent highlight
-	borderRadius: '3px',
-	border: 'solid 1px rgba(255,0,0)',
-	color: 'red',
-});
+
+let decorationType: vscode.TextEditorDecorationType;
+let showErrors = false;
 
 const errorType = vscode.window.createTextEditorDecorationType({
   backgroundColor: 'rgba(255,255,0,0.25)',
@@ -23,6 +20,10 @@ let fileSnapshot: { [fileName: string]: ts.IScriptSnapshot } = {};
 
 export async function activate(context: vscode.ExtensionContext) {
 	console.log('any-xray: activate');
+	const config = vscode.workspace.getConfiguration('anyXray');
+	const configStyle = config.get('anyStyle') as vscode.DecorationRenderOptions;
+	decorationType = vscode.window.createTextEditorDecorationType(configStyle);
+	showErrors = config.get('renderErrorAnys') as boolean;
 
   setupLanguageService();
 
@@ -120,7 +121,9 @@ function findTheAnys(document: vscode.TextDocument, editor: vscode.TextEditor) {
 				const end = node.getEnd();
 				const range = new vscode.Range(document.positionAt(start), document.positionAt(end));
 				if (type.intrinsicName === 'error') {
-					errors.push({range});
+					if (showErrors) {
+						errors.push({range});
+					}
 				} else {
 					matches.push({range});
 				}


### PR DESCRIPTION
Fixes #4 

I went ahead and supported live edit, since I think that will only get harder later. It certainly makes it easier to play around with the styles. One surprise: when you make the default an object, user-specified keys get merged in.

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/96f68a5e-0182-48b2-9044-f06a511e6eb9">
