### PR TITLE
Fixes to support `checker.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.2.1
+
+- Limit the work that `@babel/traverse` does; net effect is a speedup and the ability to run on the Mt. Everest of TypeScript, `checker.ts`. (#21)
+- Cache the AST for the active document to avoid re-parsing.
+
 ## 0.2.0
 
 - Re-architected to use VS Code's built-in TypeScript server (thanks for the tip @acutmore!).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "any-xray",
   "displayName": "any-xray",
   "description": "X-Ray vision for TypeScript 'any' types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "danvk",
   "icon": "icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ async function findTheAnys(
 	let ast;
 	if (cachedAst && cachedAst.fileName === fileName && cachedAst.generation === generation) {
 		ast = cachedAst.ast;
-		console.log('re-using cached AST');
+		// console.log('re-using cached AST');
 	} else {
 		const parseStartMs = Date.now();
 		const parsedAst = parse(document.getText(), {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,6 @@ async function findTheAnys(
   }
 
   const parseStartMs = Date.now();
-  // TODO: is jsx harmful for non-TSX?
   const ast = parse(document.getText(), {
     sourceType: "module",
     plugins: ["typescript", ...(fileName.endsWith('tsx') ? ["jsx" as const] : [])],
@@ -162,6 +161,7 @@ async function findTheAnys(
       }
       identifiers.push(node);
     },
+    noScope: true,  // See https://github.com/danvk/any-xray/issues/19
   });
   // TODO: cache generation -> AST mapping for active editor
 


### PR DESCRIPTION
Fixes #19 

The trick was to add `noScope: true` to the babel `traverse` call. I also added caching for the last AST parse (see #17) and some logic to prune the AST traversal. Babel seems very poorly documented.

The net effect is that I'm able to run the extension on `checker.ts`, the Mt. Everest of TypeScript. It even seems pretty usable!

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/b54efaad-002d-4b5a-9f24-1d4c26a32cbd">
