### PR TITLE
Version bump

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ vsc-extension-quickstart.md
 vitest.config.mts
 icon-1024.png
 out/test
+node_modules/eslint/lib/rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.3.0
+
+- Support Vue files with `<script lang="ts">`. (#23)
+- Don't report "any" types that overlap with TypeScript errors. (#24)
+
 ## 0.2.1
 
 - Limit the work that `@babel/traverse` does; net effect is a speedup and the ability to run on the Mt. Everest of TypeScript, `checker.ts`. (#21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support Vue files with `<script lang="ts">`. (#23)
 - Don't report "any" types that overlap with TypeScript errors. (#24)
+- Suppress warnings on destructuring assignment and "evolving any". (#26)
+- Change default style to be a little less aggressive. (#25)
 
 ## 0.2.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "any-xray",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "any-xray",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/parser": "^8.55.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "any-xray",
   "displayName": "any-xray",
   "description": "X-Ray vision for TypeScript 'any' types",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "publisher": "danvk",
   "icon": "icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,8 +14,8 @@ let decorationType: vscode.TextEditorDecorationType;
 const fallbackDecorationStyle: vscode.DecorationRenderOptions = {
   backgroundColor: "rgba(255,0,0,0.1)",
   borderRadius: "3px",
-  border: "solid 1px rgba(255,0,0)",
   color: "red",
+  outline: "1px solid rgba(255,0,0,0.4)",
 };
 
 interface DetectedAnys {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ let decorationType: vscode.TextEditorDecorationType;
 const fallbackDecorationStyle: vscode.DecorationRenderOptions = {
   backgroundColor: "rgba(255,0,0,0.1)",
   borderRadius: "3px",
-  color: "red",
+  // color: "red",
   outline: "1px solid rgba(255,0,0,0.4)",
 };
 


### PR DESCRIPTION
After trying and failing to bundle (#6) I just added eslint rules to the ignore list.

This adjusts the default style to use `outline` rather than `border`, which gives a little more padding around the text. It dials back opacity on the outline to make the text more visible.

Before:

<img width="443" height="191" alt="image" src="https://github.com/user-attachments/assets/604e14bf-7396-43da-82c0-6f00d800e928" />

After:

<img width="421" height="187" alt="image" src="https://github.com/user-attachments/assets/4ee7acd1-22fd-42d3-93a6-bddcf1f312b9" />
